### PR TITLE
fix parse_cmd: add catch for the function executions

### DIFF
--- a/helper/parse_cmd.js
+++ b/helper/parse_cmd.js
@@ -7,8 +7,11 @@
  * @returns func's return
  */
 
+export function parse_cmd(rawmsg, cmdlist) {
+    parse_cmd_impl(rawmsg, cmdlist).catch((e) => console.error(e));
+}
 
-export async function parse_cmd(rawmsg, cmdlist) {
+async function parse_cmd_impl(rawmsg, cmdlist) {
     for (const [cmd, func] of cmdlist) {
         if (typeof cmd == "string") {
             if (cmd[0] != '!') {


### PR DESCRIPTION
在parse_cmd上加了catch ()(超小声(